### PR TITLE
RISC-V: remove variants with medany name in it

### DIFF
--- a/build_all_bsps
+++ b/build_all_bsps
@@ -149,11 +149,8 @@ do
     riscv/rv32imafd) has_smp="yes" ;;
     riscv/rv32imafdc) has_smp="yes" ;;
     riscv/rv64imac) has_smp="yes" ;;
-    riscv/rv64imac_medany) has_smp="yes" ;;
     riscv/rv64imafd) has_smp="yes" ;;
     riscv/rv64imafdc) has_smp="yes" ;;
-    riscv/rv64imafdc_medany) has_smp="yes" ;;
-    riscv/rv64imafd_medany) has_smp="yes" ;;
     sparc/erc32) has_smp="yes" ;;
     sparc/gr712rc) has_smp="yes" ;;
     sparc/gr740) has_smp="yes" ;;


### PR DESCRIPTION
All RV64 BSPs are now medany be default. There are no rv64*_medany any more. See https://devel.rtems.org/ticket/4775